### PR TITLE
Refactor NumberProtocolParams

### DIFF
--- a/source/NumberProtocols/AdjacentSteps.cpp
+++ b/source/NumberProtocols/AdjacentSteps.cpp
@@ -41,7 +41,7 @@ double AdjacentSteps::getDecimalNumber()
     return static_cast<double>(getIntegerNumber());
 }
 
-void AdjacentSteps::setParams(NumberProtocolParameters newParams)
+void AdjacentSteps::setParams(NumberProtocolConfig newParams)
 {
     m_range = newParams.getRange();
     m_generator->setDistributionVector(m_range.size, 1.0);
@@ -52,12 +52,10 @@ void AdjacentSteps::setParams(NumberProtocolParameters newParams)
     }
 }
 
-NumberProtocolParameters AdjacentSteps::getParams()
+NumberProtocolConfig AdjacentSteps::getParams()
 {
-    return NumberProtocolParameters(
-        m_range,
-        NumberProtocolParameters::Protocols(
-            NumberProtocolParameters::AdjacentSteps()));
+    return NumberProtocolConfig(m_range,
+                                NumberProtocolParams(AdjacentStepsParams()));
 }
 
 void AdjacentSteps::prepareStepBasedDistribution(int number)

--- a/source/NumberProtocols/AdjacentSteps.hpp
+++ b/source/NumberProtocols/AdjacentSteps.hpp
@@ -66,9 +66,9 @@ class AdjacentSteps : public NumberProtocol {
 
     double getDecimalNumber() override;
 
-    void setParams(NumberProtocolParameters newParams) override;
+    void setParams(NumberProtocolConfig newParams) override;
 
-    NumberProtocolParameters getParams() override;
+    NumberProtocolConfig getParams() override;
 
   private:
     std::unique_ptr<IDiscreteGenerator> m_generator;

--- a/source/NumberProtocols/Basic.cpp
+++ b/source/NumberProtocols/Basic.cpp
@@ -26,14 +26,12 @@ double Basic::getDecimalNumber()
     return static_cast<double>(getIntegerNumber());
 }
 
-NumberProtocolParameters Basic::getParams()
+NumberProtocolConfig Basic::getParams()
 {
-    return NumberProtocolParameters(
-        m_range,
-        NumberProtocolParameters::Protocols(NumberProtocolParameters::Basic()));
+    return NumberProtocolConfig(m_range, NumberProtocolParams(BasicParams()));
 }
 
-void Basic::setParams(NumberProtocolParameters newParams)
+void Basic::setParams(NumberProtocolConfig newParams)
 {
     m_range = newParams.getRange();
     m_generator->setDistribution(m_range.start, m_range.end);

--- a/source/NumberProtocols/Basic.hpp
+++ b/source/NumberProtocols/Basic.hpp
@@ -39,9 +39,9 @@ class Basic : public NumberProtocol {
 
     double getDecimalNumber() override;
 
-    NumberProtocolParameters getParams() override;
+    NumberProtocolConfig getParams() override;
 
-    void setParams(NumberProtocolParameters newParams) override;
+    void setParams(NumberProtocolConfig newParams) override;
 
   private:
     std::unique_ptr<IUniformGenerator> m_generator;

--- a/source/NumberProtocols/Cycle.cpp
+++ b/source/NumberProtocols/Cycle.cpp
@@ -37,7 +37,7 @@ double Cycle::getDecimalNumber()
     return static_cast<double>(getIntegerNumber());
 }
 
-void Cycle::setParams(NumberProtocolParameters newParams)
+void Cycle::setParams(NumberProtocolConfig newParams)
 {
     auto cycleParams = newParams.protocols.getCycle();
     m_bidirectional = cycleParams.getBidirectional();
@@ -47,13 +47,11 @@ void Cycle::setParams(NumberProtocolParameters newParams)
     setRange(newParams.getRange());
 }
 
-NumberProtocolParameters Cycle::getParams()
+NumberProtocolConfig Cycle::getParams()
 {
-    return NumberProtocolParameters(
+    return NumberProtocolConfig(
         m_range,
-        NumberProtocolParameters::Protocols(
-            NumberProtocolParameters::Cycle(m_bidirectional,
-                                            m_reverseDirection)));
+        NumberProtocolParams(CycleParams(m_bidirectional, m_reverseDirection)));
 }
 
 // Private methods

--- a/source/NumberProtocols/Cycle.hpp
+++ b/source/NumberProtocols/Cycle.hpp
@@ -24,9 +24,9 @@ class Cycle : public NumberProtocol {
 
     double getDecimalNumber() override;
 
-    void setParams(NumberProtocolParameters newParams) override;
+    void setParams(NumberProtocolConfig newParams) override;
 
-    NumberProtocolParameters getParams() override;
+    NumberProtocolConfig getParams() override;
 
   private:
     Range m_range;

--- a/source/NumberProtocols/GranularWalk.cpp
+++ b/source/NumberProtocols/GranularWalk.cpp
@@ -47,7 +47,7 @@ double GranularWalk::getDecimalNumber()
     return m_lastReturnedNumber;
 }
 
-void GranularWalk::setParams(NumberProtocolParameters newParams)
+void GranularWalk::setParams(NumberProtocolConfig newParams)
 {
     auto granWalkParams = newParams.protocols.getGranularWalk();
 
@@ -60,12 +60,11 @@ void GranularWalk::setParams(NumberProtocolParameters newParams)
     setRange(newParams.getRange());
 }
 
-NumberProtocolParameters GranularWalk::getParams()
+NumberProtocolConfig GranularWalk::getParams()
 {
-    return NumberProtocolParameters(
+    return NumberProtocolConfig(
         m_range,
-        NumberProtocolParameters::Protocols(
-            NumberProtocolParameters::GranularWalk(m_deviationFactor)));
+        NumberProtocolParams(GranularWalkParams(m_deviationFactor)));
 }
 
 // Private methods=====================================================

--- a/source/NumberProtocols/GranularWalk.hpp
+++ b/source/NumberProtocols/GranularWalk.hpp
@@ -104,9 +104,9 @@ class GranularWalk : public NumberProtocol {
      */
     double getDecimalNumber() override;
 
-    void setParams(NumberProtocolParameters newParams) override;
+    void setParams(NumberProtocolConfig newParams) override;
 
-    NumberProtocolParameters getParams() override;
+    NumberProtocolConfig getParams() override;
 
   private:
     std::unique_ptr<UniformRealGenerator> m_generator;

--- a/source/NumberProtocols/GroupedRepetition.cpp
+++ b/source/NumberProtocols/GroupedRepetition.cpp
@@ -60,7 +60,7 @@ double GroupedRepetition::getDecimalNumber()
     return static_cast<double>(getIntegerNumber());
 }
 
-void GroupedRepetition::setParams(NumberProtocolParameters newParams)
+void GroupedRepetition::setParams(NumberProtocolConfig newParams)
 {
     m_groupings = newParams.protocols.getGroupedRepetition().getGroupings();
     m_groupingGenerator->setDistributionVector(m_groupings.size(), 1.0);
@@ -71,12 +71,11 @@ void GroupedRepetition::setParams(NumberProtocolParameters newParams)
     m_groupingCount = 0;
 }
 
-NumberProtocolParameters GroupedRepetition::getParams()
+NumberProtocolConfig GroupedRepetition::getParams()
 {
-    return NumberProtocolParameters(
+    return NumberProtocolConfig(
         m_range,
-        NumberProtocolParameters::Protocols(
-            NumberProtocolParameters::GroupedRepetition(m_groupings)));
+        NumberProtocolParams(GroupedRepetitionParams(m_groupings)));
 }
 
 // Private methods

--- a/source/NumberProtocols/GroupedRepetition.hpp
+++ b/source/NumberProtocols/GroupedRepetition.hpp
@@ -27,9 +27,9 @@ class GroupedRepetition : public NumberProtocol {
 
     double getDecimalNumber() override;
 
-    void setParams(NumberProtocolParameters newParams) override;
+    void setParams(NumberProtocolConfig newParams) override;
 
-    NumberProtocolParameters getParams() override;
+    NumberProtocolConfig getParams() override;
 
   private:
     std::unique_ptr<IDiscreteGenerator> m_numberGenerator;

--- a/source/NumberProtocols/NoRepetition.cpp
+++ b/source/NumberProtocols/NoRepetition.cpp
@@ -38,7 +38,7 @@ double NoRepetition::getDecimalNumber()
     return static_cast<double>(getIntegerNumber());
 }
 
-void NoRepetition::setParams(NumberProtocolParameters newParams)
+void NoRepetition::setParams(NumberProtocolConfig newParams)
 {
     auto newRange = newParams.getRange();
     m_generator->setDistributionVector(newRange.size, 1.0);
@@ -53,12 +53,10 @@ void NoRepetition::setParams(NumberProtocolParameters newParams)
     m_range = newRange;
 }
 
-NumberProtocolParameters NoRepetition::getParams()
+NumberProtocolConfig NoRepetition::getParams()
 {
-    return NumberProtocolParameters(
-        m_range,
-        NumberProtocolParameters::Protocols(
-            NumberProtocolParameters::NoRepetition()));
+    return NumberProtocolConfig(m_range,
+                                NumberProtocolParams(NoRepetitionParams()));
 }
 
 } // namespace aleatoric

--- a/source/NumberProtocols/NoRepetition.hpp
+++ b/source/NumberProtocols/NoRepetition.hpp
@@ -54,9 +54,9 @@ class NoRepetition : public NumberProtocol {
 
     double getDecimalNumber() override;
 
-    void setParams(NumberProtocolParameters newParams) override;
+    void setParams(NumberProtocolConfig newParams) override;
 
-    NumberProtocolParameters getParams() override;
+    NumberProtocolConfig getParams() override;
 
   private:
     std::unique_ptr<IDiscreteGenerator> m_generator;

--- a/source/NumberProtocols/NumberProtocol.hpp
+++ b/source/NumberProtocols/NumberProtocol.hpp
@@ -1,12 +1,13 @@
 #ifndef NumberProtocol_hpp
 #define NumberProtocol_hpp
 
-#include "NumberProtocolParameters.hpp"
+// #include "NumberProtocolParameters.hpp"
 #include "Range.hpp"
 
 #include <memory>
 
 namespace aleatoric {
+struct NumberProtocolConfig; // forward dec preventing circular dep
 
 /*! @brief Interface to which concrete protocol classes that produce random
  * numbers must conform
@@ -24,9 +25,9 @@ class NumberProtocol {
 
     virtual double getDecimalNumber() = 0;
 
-    virtual void setParams(NumberProtocolParameters newParams) = 0;
+    virtual void setParams(NumberProtocolConfig newParams) = 0;
 
-    virtual NumberProtocolParameters getParams() = 0;
+    virtual NumberProtocolConfig getParams() = 0;
 
     virtual ~NumberProtocol() = default;
 
@@ -42,7 +43,8 @@ class NumberProtocol {
         ratio,
         serial,
         subset,
-        walk
+        walk,
+        none
     };
 
     static std::unique_ptr<NumberProtocol> create(Type type);

--- a/source/NumberProtocols/NumberProtocolParameters.cpp
+++ b/source/NumberProtocols/NumberProtocolParameters.cpp
@@ -2,32 +2,32 @@
 
 namespace aleatoric {
 
-NumberProtocolParameters::NumberProtocolParameters(Range newRange,
-                                                   Protocols protocolsParams)
+NumberProtocolConfig::NumberProtocolConfig(Range newRange,
+                                           NumberProtocolParams protocolsParams)
 {
     m_range = newRange;
     protocols = protocolsParams;
 }
 
-NumberProtocolParameters::NumberProtocolParameters(Range newRange)
+NumberProtocolConfig::NumberProtocolConfig(Range newRange)
 {
     m_range = newRange;
-    protocols.m_subset = Subset(1, newRange.size);
+    protocols.m_subset = SubsetParams(1, newRange.size);
 
     std::vector<int> ratios(newRange.size);
     for(auto &&i : ratios) {
         i = 1;
     }
-    protocols.m_ratio = Ratio(ratios);
+    protocols.m_ratio = RatioParams(ratios);
 
     std::vector<double> distribution(newRange.size);
     for(auto &&i : distribution) {
         i = 1.0 / distribution.size();
     }
-    protocols.m_precision = Precision(distribution);
+    protocols.m_precision = PrecisionParams(distribution);
 }
 
-Range NumberProtocolParameters::getRange()
+Range NumberProtocolConfig::getRange()
 {
     return m_range;
 }
@@ -35,153 +35,145 @@ Range NumberProtocolParameters::getRange()
 // Protocols =====================================================
 
 // Constructors
-NumberProtocolParameters::Protocols::Protocols()
+NumberProtocolParams::NumberProtocolParams()
 {}
 
-NumberProtocolParameters::Protocols::Protocols(AdjacentSteps protocolParams)
+NumberProtocolParams::NumberProtocolParams(AdjacentStepsParams protocolParams)
 {
-    m_activeProtocol = Protocols::ActiveProtocol::adjacentSteps;
+    m_activeProtocol = NumberProtocol::Type::adjacentSteps;
     m_adjacentSteps = protocolParams;
 }
 
-NumberProtocolParameters::Protocols::Protocols(Basic protocolParams)
+NumberProtocolParams::NumberProtocolParams(BasicParams protocolParams)
 {
-    m_activeProtocol = Protocols::ActiveProtocol::basic;
+    m_activeProtocol = NumberProtocol::Type::basic;
     m_basic = protocolParams;
 }
 
-NumberProtocolParameters::Protocols::Protocols(Cycle protocolParams)
+NumberProtocolParams::NumberProtocolParams(CycleParams protocolParams)
 {
-    m_activeProtocol = Protocols::ActiveProtocol::cycle;
+    m_activeProtocol = NumberProtocol::Type::cycle;
     m_cycle = protocolParams;
 }
 
-NumberProtocolParameters::Protocols::Protocols(GranularWalk protocolParams)
+NumberProtocolParams::NumberProtocolParams(GranularWalkParams protocolParams)
 {
-    m_activeProtocol = Protocols::ActiveProtocol::granularWalk;
+    m_activeProtocol = NumberProtocol::Type::granularWalk;
     m_granularWalk = protocolParams;
 }
 
-NumberProtocolParameters::Protocols::Protocols(GroupedRepetition protocolParams)
+NumberProtocolParams::NumberProtocolParams(
+    GroupedRepetitionParams protocolParams)
 {
-    m_activeProtocol = Protocols::ActiveProtocol::groupedRepetition;
+    m_activeProtocol = NumberProtocol::Type::groupedRepetition;
     m_groupedRepetition = protocolParams;
 }
 
-NumberProtocolParameters::Protocols::Protocols(NoRepetition protocolParams)
+NumberProtocolParams::NumberProtocolParams(NoRepetitionParams protocolParams)
 {
-    m_activeProtocol = Protocols::ActiveProtocol::noRepetition;
+    m_activeProtocol = NumberProtocol::Type::noRepetition;
     m_noRepetition = protocolParams;
 }
 
-NumberProtocolParameters::Protocols::Protocols(Periodic protocolParams)
+NumberProtocolParams::NumberProtocolParams(PeriodicParams protocolParams)
 {
-    m_activeProtocol = Protocols::ActiveProtocol::periodic;
+    m_activeProtocol = NumberProtocol::Type::periodic;
     m_periodic = protocolParams;
 }
 
-NumberProtocolParameters::Protocols::Protocols(Precision protocolParams)
+NumberProtocolParams::NumberProtocolParams(PrecisionParams protocolParams)
 {
-    m_activeProtocol = Protocols::ActiveProtocol::precision;
+    m_activeProtocol = NumberProtocol::Type::precision;
     m_precision = protocolParams;
 }
 
-NumberProtocolParameters::Protocols::Protocols(Ratio protocolParams)
+NumberProtocolParams::NumberProtocolParams(RatioParams protocolParams)
 {
-    m_activeProtocol = Protocols::ActiveProtocol::ratio;
+    m_activeProtocol = NumberProtocol::Type::ratio;
     m_ratio = protocolParams;
 }
 
-NumberProtocolParameters::Protocols::Protocols(Serial protocolParams)
+NumberProtocolParams::NumberProtocolParams(SerialParams protocolParams)
 {
-    m_activeProtocol = Protocols::ActiveProtocol::serial;
+    m_activeProtocol = NumberProtocol::Type::serial;
     m_serial = protocolParams;
 }
 
-NumberProtocolParameters::Protocols::Protocols(Subset protocolParams)
+NumberProtocolParams::NumberProtocolParams(SubsetParams protocolParams)
 {
-    m_activeProtocol = Protocols::ActiveProtocol::subset;
+    m_activeProtocol = NumberProtocol::Type::subset;
     m_subset = protocolParams;
 }
 
-NumberProtocolParameters::Protocols::Protocols(Walk protocolParams)
+NumberProtocolParams::NumberProtocolParams(WalkParams protocolParams)
 {
-    m_activeProtocol = Protocols::ActiveProtocol::walk;
+    m_activeProtocol = NumberProtocol::Type::walk;
     m_walk = protocolParams;
 }
 
 // other methods
 
-NumberProtocolParameters::Protocols::ActiveProtocol
-NumberProtocolParameters::Protocols::getActiveProtocol()
+NumberProtocol::Type NumberProtocolParams::getActiveProtocol()
 {
     return m_activeProtocol;
 }
 
-NumberProtocolParameters::AdjacentSteps
-NumberProtocolParameters::Protocols::getAdjacentSteps()
+AdjacentStepsParams NumberProtocolParams::getAdjacentSteps()
 {
     return m_adjacentSteps;
 }
 
-NumberProtocolParameters::Basic NumberProtocolParameters::Protocols::getBasic()
+BasicParams NumberProtocolParams::getBasic()
 {
     return m_basic;
 }
 
-NumberProtocolParameters::Cycle NumberProtocolParameters::Protocols::getCycle()
+CycleParams NumberProtocolParams::getCycle()
 {
     return m_cycle;
 }
 
-NumberProtocolParameters::GranularWalk
-NumberProtocolParameters::Protocols::getGranularWalk()
+GranularWalkParams NumberProtocolParams::getGranularWalk()
 {
     return m_granularWalk;
 }
 
-NumberProtocolParameters::GroupedRepetition
-NumberProtocolParameters::Protocols::getGroupedRepetition()
+GroupedRepetitionParams NumberProtocolParams::getGroupedRepetition()
 {
     return m_groupedRepetition;
 }
 
-NumberProtocolParameters::NoRepetition
-NumberProtocolParameters::Protocols::getNoRepetition()
+NoRepetitionParams NumberProtocolParams::getNoRepetition()
 {
     return m_noRepetition;
 }
 
-NumberProtocolParameters::Periodic
-NumberProtocolParameters::Protocols::getPeriodic()
+PeriodicParams NumberProtocolParams::getPeriodic()
 {
     return m_periodic;
 }
 
-NumberProtocolParameters::Precision
-NumberProtocolParameters::Protocols::getPrecision()
+PrecisionParams NumberProtocolParams::getPrecision()
 {
     return m_precision;
 }
 
-NumberProtocolParameters::Ratio NumberProtocolParameters::Protocols::getRatio()
+RatioParams NumberProtocolParams::getRatio()
 {
     return m_ratio;
 }
 
-NumberProtocolParameters::Serial
-NumberProtocolParameters::Protocols::getSerial()
+SerialParams NumberProtocolParams::getSerial()
 {
     return m_serial;
 }
 
-NumberProtocolParameters::Subset
-NumberProtocolParameters::Protocols::getSubset()
+SubsetParams NumberProtocolParams::getSubset()
 {
     return m_subset;
 }
 
-NumberProtocolParameters::Walk NumberProtocolParameters::Protocols::getWalk()
+WalkParams NumberProtocolParams::getWalk()
 {
     return m_walk;
 }
@@ -189,127 +181,125 @@ NumberProtocolParameters::Walk NumberProtocolParameters::Protocols::getWalk()
 // ===============================================================
 
 // Cycle
-NumberProtocolParameters::Cycle::Cycle()
+CycleParams::CycleParams()
 {}
 
-NumberProtocolParameters::Cycle::Cycle(bool bidirectional,
-                                       bool reverseDirection)
+CycleParams::CycleParams(bool bidirectional, bool reverseDirection)
 {
     m_bidirectional = bidirectional;
     m_reverseDirection = reverseDirection;
 }
 
-bool NumberProtocolParameters::Cycle::getBidirectional()
+bool CycleParams::getBidirectional()
 {
     return m_bidirectional;
 }
 
-bool NumberProtocolParameters::Cycle::getReverseDirection()
+bool CycleParams::getReverseDirection()
 {
     return m_reverseDirection;
 }
 
 // GranularWalk
-NumberProtocolParameters::GranularWalk::GranularWalk()
+GranularWalkParams::GranularWalkParams()
 {}
 
-NumberProtocolParameters::GranularWalk::GranularWalk(double deviationFactor)
+GranularWalkParams::GranularWalkParams(double deviationFactor)
 {
     m_deviationFactor = deviationFactor;
 }
 
-double NumberProtocolParameters::GranularWalk::getDeviationFactor()
+double GranularWalkParams::getDeviationFactor()
 {
     return m_deviationFactor;
 }
 
 // Grouped Repetition
-NumberProtocolParameters::GroupedRepetition::GroupedRepetition()
+GroupedRepetitionParams::GroupedRepetitionParams()
 {}
 
-NumberProtocolParameters::GroupedRepetition::GroupedRepetition(
-    std::vector<int> groupings)
+GroupedRepetitionParams::GroupedRepetitionParams(std::vector<int> groupings)
 {
     m_groupings = groupings;
 }
 
-std::vector<int> NumberProtocolParameters::GroupedRepetition::getGroupings()
+std::vector<int> GroupedRepetitionParams::getGroupings()
 {
     return m_groupings;
 }
 
 // Periodic
-NumberProtocolParameters::Periodic::Periodic()
+PeriodicParams::PeriodicParams()
 {}
 
-NumberProtocolParameters::Periodic::Periodic(double chanceOfRepetition)
+PeriodicParams::PeriodicParams(double chanceOfRepetition)
 {
     m_chanceOfRepetition = chanceOfRepetition;
 }
 
-double NumberProtocolParameters::Periodic::getChanceOfRepetition()
+double PeriodicParams::getChanceOfRepetition()
 {
     return m_chanceOfRepetition;
 }
 
 // Precision
-NumberProtocolParameters::Precision::Precision()
+PrecisionParams::PrecisionParams()
 {}
 
-NumberProtocolParameters::Precision::Precision(std::vector<double> distribution)
+PrecisionParams::PrecisionParams(std::vector<double> distribution)
 {
     m_distribution = distribution;
 }
 
-std::vector<double> NumberProtocolParameters::Precision::getDistribution()
+std::vector<double> PrecisionParams::getDistribution()
 {
     return m_distribution;
 }
 
 // Ratio
-NumberProtocolParameters::Ratio::Ratio()
+RatioParams::RatioParams()
 {}
 
-NumberProtocolParameters::Ratio::Ratio(std::vector<int> ratios)
+RatioParams::RatioParams(std::vector<int> ratios)
 {
     m_ratios = ratios;
 }
 
-std::vector<int> NumberProtocolParameters::Ratio::getRatios()
+std::vector<int> RatioParams::getRatios()
 {
     return m_ratios;
 }
 
 // Subset
-NumberProtocolParameters::Subset::Subset()
+SubsetParams::SubsetParams()
 {}
 
-NumberProtocolParameters::Subset::Subset(int min, int max)
+SubsetParams::SubsetParams(int min, int max)
 {
     m_min = min;
     m_max = max;
 }
 
-int NumberProtocolParameters::Subset::getMin()
+int SubsetParams::getMin()
 {
     return m_min;
 }
 
-int NumberProtocolParameters::Subset::getMax()
+int SubsetParams::getMax()
 {
     return m_max;
 }
 
 // Walk
-NumberProtocolParameters::Walk::Walk()
+WalkParams::WalkParams()
 {}
 
-NumberProtocolParameters::Walk::Walk(int maxStep)
+WalkParams::WalkParams(int maxStep)
 {
     m_maxStep = maxStep;
 }
 
-int NumberProtocolParameters::Walk::getMaxStep()
+int WalkParams::getMaxStep()
 {
     return m_maxStep;
 }

--- a/source/NumberProtocols/NumberProtocolParameters.hpp
+++ b/source/NumberProtocols/NumberProtocolParameters.hpp
@@ -1,176 +1,162 @@
 #ifndef NumberProtocolParameters_hpp
 #define NumberProtocolParameters_hpp
 
+#include "NumberProtocol.hpp"
 #include "Range.hpp"
 
 #include <vector>
 
 namespace aleatoric {
 
-struct NumberProtocolParameters {
-    struct Protocols; // forward declaration for setting up friend relationships
+struct NumberProtocolParams; // forward declaration for setting up friend
+                             // relationships
 
-    struct AdjacentSteps {};
+struct AdjacentStepsParams {};
 
-    struct Basic {};
+struct BasicParams {};
 
-    struct Cycle {
-        Cycle(bool bidirectional, bool reverseDirection);
-        friend struct Protocols;
-        bool getBidirectional();
-        bool getReverseDirection();
+struct CycleParams {
+    CycleParams(bool bidirectional, bool reverseDirection);
+    friend struct NumberProtocolParams;
+    bool getBidirectional();
+    bool getReverseDirection();
 
-      private:
-        Cycle();
-        bool m_bidirectional = false;
-        bool m_reverseDirection = false;
-    };
+  private:
+    CycleParams();
+    bool m_bidirectional = false;
+    bool m_reverseDirection = false;
+};
 
-    struct GranularWalk {
-        GranularWalk(double deviationFactor);
-        friend struct Protocols;
-        double getDeviationFactor();
+struct GranularWalkParams {
+    GranularWalkParams(double deviationFactor);
+    friend struct NumberProtocolParams;
+    double getDeviationFactor();
 
-      private:
-        GranularWalk();
-        double m_deviationFactor = 1.0;
-    };
+  private:
+    GranularWalkParams();
+    double m_deviationFactor = 1.0;
+};
 
-    struct GroupedRepetition {
-        GroupedRepetition(std::vector<int> groupings);
-        friend struct Protocols;
-        std::vector<int> getGroupings();
+struct GroupedRepetitionParams {
+    GroupedRepetitionParams(std::vector<int> groupings);
+    friend struct NumberProtocolParams;
+    std::vector<int> getGroupings();
 
-      private:
-        GroupedRepetition();
-        std::vector<int> m_groupings {1};
-    };
+  private:
+    GroupedRepetitionParams();
+    std::vector<int> m_groupings {1};
+};
 
-    struct NoRepetition {};
+struct NoRepetitionParams {};
 
-    struct Periodic {
-        Periodic(double chanceOfRepetition);
-        friend struct Protocols;
-        double getChanceOfRepetition();
+struct PeriodicParams {
+    PeriodicParams(double chanceOfRepetition);
+    friend struct NumberProtocolParams;
+    double getChanceOfRepetition();
 
-      private:
-        Periodic();
-        double m_chanceOfRepetition = 0.0;
-    };
+  private:
+    PeriodicParams();
+    double m_chanceOfRepetition = 0.0;
+};
 
-    struct Precision {
-        Precision(std::vector<double> distribution);
-        friend struct Protocols;
-        std::vector<double> getDistribution();
+struct PrecisionParams {
+    PrecisionParams(std::vector<double> distribution);
+    friend struct NumberProtocolParams;
+    std::vector<double> getDistribution();
 
-      private:
-        Precision();
-        std::vector<double> m_distribution {};
-    };
+  private:
+    PrecisionParams();
+    std::vector<double> m_distribution {};
+};
 
-    struct Ratio {
-        Ratio(std::vector<int> ratios);
-        friend struct Protocols;
-        std::vector<int> getRatios();
+struct RatioParams {
+    RatioParams(std::vector<int> ratios);
+    friend struct NumberProtocolParams;
+    std::vector<int> getRatios();
 
-      private:
-        Ratio();
-        std::vector<int> m_ratios {};
-    };
+  private:
+    RatioParams();
+    std::vector<int> m_ratios {};
+};
 
-    struct Serial {};
+struct SerialParams {};
 
-    struct Subset {
-        Subset(int min, int max);
-        friend struct Protocols;
-        int getMin();
-        int getMax();
+struct SubsetParams {
+    SubsetParams(int min, int max);
+    friend struct NumberProtocolParams;
+    int getMin();
+    int getMax();
 
-      private:
-        Subset();
-        int m_min = 0;
-        int m_max = 0;
-    };
+  private:
+    SubsetParams();
+    int m_min = 0;
+    int m_max = 0;
+};
 
-    struct Walk {
-        Walk(int maxStep);
-        friend struct Protocols;
-        int getMaxStep();
+struct WalkParams {
+    WalkParams(int maxStep);
+    friend struct NumberProtocolParams;
+    int getMaxStep();
 
-      private:
-        Walk();
-        int m_maxStep = 1;
-    };
+  private:
+    WalkParams();
+    int m_maxStep = 1;
+};
 
-    struct Protocols {
-        enum class ActiveProtocol {
-            adjacentSteps,
-            basic,
-            cycle,
-            granularWalk,
-            groupedRepetition,
-            noRepetition,
-            periodic,
-            precision,
-            ratio,
-            serial,
-            subset,
-            walk,
-            none
-        };
+struct NumberProtocolParams {
+    friend struct NumberProtocolConfig;
 
-        friend struct NumberProtocolParameters;
+    NumberProtocolParams(AdjacentStepsParams protocolParams);
+    NumberProtocolParams(BasicParams protocolParams);
+    NumberProtocolParams(CycleParams protocolParams);
+    NumberProtocolParams(GranularWalkParams protocolParams);
+    NumberProtocolParams(GroupedRepetitionParams protocolParams);
+    NumberProtocolParams(NoRepetitionParams protocolParams);
+    NumberProtocolParams(PeriodicParams protocolParams);
+    NumberProtocolParams(PrecisionParams protocolParams);
+    NumberProtocolParams(RatioParams protocolParams);
+    NumberProtocolParams(SerialParams protocolParams);
+    NumberProtocolParams(SubsetParams protocolParams);
+    NumberProtocolParams(WalkParams protocolParams);
 
-        Protocols(AdjacentSteps protocolParams);
-        Protocols(Basic protocolParams);
-        Protocols(Cycle protocolParams);
-        Protocols(GranularWalk protocolParams);
-        Protocols(GroupedRepetition protocolParams);
-        Protocols(NoRepetition protocolParams);
-        Protocols(Periodic protocolParams);
-        Protocols(Precision protocolParams);
-        Protocols(Ratio protocolParams);
-        Protocols(Serial protocolParams);
-        Protocols(Subset protocolParams);
-        Protocols(Walk protocolParams);
+    NumberProtocol::Type getActiveProtocol();
+    AdjacentStepsParams getAdjacentSteps();
+    BasicParams getBasic();
+    CycleParams getCycle();
+    GranularWalkParams getGranularWalk();
+    GroupedRepetitionParams getGroupedRepetition();
+    NoRepetitionParams getNoRepetition();
+    PeriodicParams getPeriodic();
+    PrecisionParams getPrecision();
+    RatioParams getRatio();
+    SerialParams getSerial();
+    SubsetParams getSubset();
+    WalkParams getWalk();
 
-        ActiveProtocol getActiveProtocol();
-        AdjacentSteps getAdjacentSteps();
-        Basic getBasic();
-        Cycle getCycle();
-        GranularWalk getGranularWalk();
-        GroupedRepetition getGroupedRepetition();
-        NoRepetition getNoRepetition();
-        Periodic getPeriodic();
-        Precision getPrecision();
-        Ratio getRatio();
-        Serial getSerial();
-        Subset getSubset();
-        Walk getWalk();
+  private:
+    NumberProtocolParams();
+    NumberProtocol::Type m_activeProtocol = NumberProtocol::Type::none;
 
-      private:
-        Protocols();
-        ActiveProtocol m_activeProtocol = ActiveProtocol::none;
+    AdjacentStepsParams m_adjacentSteps;
+    BasicParams m_basic;
+    CycleParams m_cycle;
+    GranularWalkParams m_granularWalk;
+    GroupedRepetitionParams m_groupedRepetition;
+    NoRepetitionParams m_noRepetition;
+    PeriodicParams m_periodic;
+    PrecisionParams m_precision;
+    RatioParams m_ratio;
+    SerialParams m_serial;
+    SubsetParams m_subset;
+    WalkParams m_walk;
+};
 
-        AdjacentSteps m_adjacentSteps;
-        Basic m_basic;
-        Cycle m_cycle;
-        GranularWalk m_granularWalk;
-        GroupedRepetition m_groupedRepetition;
-        NoRepetition m_noRepetition;
-        Periodic m_periodic;
-        Precision m_precision;
-        Ratio m_ratio;
-        Serial m_serial;
-        Subset m_subset;
-        Walk m_walk;
-    };
-
-    NumberProtocolParameters(Range newRange, Protocols protocolsParams);
+struct NumberProtocolConfig {
+    NumberProtocolConfig(Range newRange, NumberProtocolParams protocolsParams);
 
     Range getRange();
 
-    Protocols protocols;
+    NumberProtocolParams protocols;
 
     template<typename>
     friend class CollectionsProducer;
@@ -178,7 +164,7 @@ struct NumberProtocolParameters {
     friend class DurationsProducer;
 
   private:
-    NumberProtocolParameters(Range newRange);
+    NumberProtocolConfig(Range newRange);
     Range m_range = Range(0, 1);
 };
 

--- a/source/NumberProtocols/Periodic.cpp
+++ b/source/NumberProtocols/Periodic.cpp
@@ -46,15 +46,14 @@ double Periodic::getDecimalNumber()
     return static_cast<double>(getIntegerNumber());
 }
 
-NumberProtocolParameters Periodic::getParams()
+NumberProtocolConfig Periodic::getParams()
 {
-    return NumberProtocolParameters(
+    return NumberProtocolConfig(
         m_range,
-        NumberProtocolParameters::Protocols(
-            NumberProtocolParameters::Periodic(m_periodicity)));
+        NumberProtocolParams(PeriodicParams(m_periodicity)));
 }
 
-void Periodic::setParams(NumberProtocolParameters params)
+void Periodic::setParams(NumberProtocolConfig params)
 {
     auto chanceOfRepetition =
         params.protocols.getPeriodic().getChanceOfRepetition();

--- a/source/NumberProtocols/Periodic.hpp
+++ b/source/NumberProtocols/Periodic.hpp
@@ -83,9 +83,9 @@ class Periodic : public NumberProtocol {
 
     double getDecimalNumber() override;
 
-    void setParams(NumberProtocolParameters newParams) override;
+    void setParams(NumberProtocolConfig newParams) override;
 
-    NumberProtocolParameters getParams() override;
+    NumberProtocolConfig getParams() override;
 
   private:
     std::unique_ptr<IDiscreteGenerator> m_generator;

--- a/source/NumberProtocols/Precision.cpp
+++ b/source/NumberProtocols/Precision.cpp
@@ -31,7 +31,7 @@ double Precision::getDecimalNumber()
     return static_cast<double>(getIntegerNumber());
 }
 
-void Precision::setParams(NumberProtocolParameters newParams)
+void Precision::setParams(NumberProtocolConfig newParams)
 {
     auto newDistribution = newParams.protocols.getPrecision().getDistribution();
     auto newRange = newParams.getRange();
@@ -40,12 +40,11 @@ void Precision::setParams(NumberProtocolParameters newParams)
     m_range = newRange;
 }
 
-NumberProtocolParameters Precision::getParams()
+NumberProtocolConfig Precision::getParams()
 {
-    return NumberProtocolParameters(
-        m_range,
-        NumberProtocolParameters::Protocols(NumberProtocolParameters::Precision(
-            m_generator->getDistributionVector())));
+    return NumberProtocolConfig(m_range,
+                                NumberProtocolParams(PrecisionParams(
+                                    m_generator->getDistributionVector())));
 }
 
 // Private methods

--- a/source/NumberProtocols/Precision.hpp
+++ b/source/NumberProtocols/Precision.hpp
@@ -20,9 +20,9 @@ class Precision : public NumberProtocol {
 
     double getDecimalNumber() override;
 
-    void setParams(NumberProtocolParameters newParams) override;
+    void setParams(NumberProtocolConfig newParams) override;
 
-    NumberProtocolParameters getParams() override;
+    NumberProtocolConfig getParams() override;
 
   private:
     std::unique_ptr<IDiscreteGenerator> m_generator;

--- a/source/NumberProtocols/Ratio.cpp
+++ b/source/NumberProtocols/Ratio.cpp
@@ -44,7 +44,7 @@ double Ratio::getDecimalNumber()
     return static_cast<double>(getIntegerNumber());
 }
 
-void Ratio::setParams(NumberProtocolParameters newParams)
+void Ratio::setParams(NumberProtocolConfig newParams)
 {
     auto newRatios = newParams.protocols.getRatio().getRatios();
     auto newRange = newParams.getRange();
@@ -56,12 +56,10 @@ void Ratio::setParams(NumberProtocolParameters newParams)
     m_generator->setDistributionVector(m_selectables.size(), 1.0);
 }
 
-NumberProtocolParameters Ratio::getParams()
+NumberProtocolConfig Ratio::getParams()
 {
-    return NumberProtocolParameters(
-        m_range,
-        NumberProtocolParameters::Protocols(
-            NumberProtocolParameters::Ratio(m_ratios)));
+    return NumberProtocolConfig(m_range,
+                                NumberProtocolParams(RatioParams(m_ratios)));
 }
 
 // Private methods

--- a/source/NumberProtocols/Ratio.hpp
+++ b/source/NumberProtocols/Ratio.hpp
@@ -25,9 +25,9 @@ class Ratio : public NumberProtocol {
 
     double getDecimalNumber() override;
 
-    void setParams(NumberProtocolParameters newParams) override;
+    void setParams(NumberProtocolConfig newParams) override;
 
-    NumberProtocolParameters getParams() override;
+    NumberProtocolConfig getParams() override;
 
   private:
     std::unique_ptr<IDiscreteGenerator> m_generator;

--- a/source/NumberProtocols/Serial.cpp
+++ b/source/NumberProtocols/Serial.cpp
@@ -37,17 +37,15 @@ double Serial::getDecimalNumber()
     return static_cast<double>(getIntegerNumber());
 }
 
-void Serial::setParams(NumberProtocolParameters newParams)
+void Serial::setParams(NumberProtocolConfig newParams)
 {
     m_range = newParams.getRange();
     m_generator->setDistributionVector(m_range.size, 1.0);
 }
 
-NumberProtocolParameters Serial::getParams()
+NumberProtocolConfig Serial::getParams()
 {
-    return NumberProtocolParameters(m_range,
-                                    NumberProtocolParameters::Protocols(
-                                        NumberProtocolParameters::Serial()));
+    return NumberProtocolConfig(m_range, NumberProtocolParams(SerialParams()));
 }
 
 } // namespace aleatoric

--- a/source/NumberProtocols/Serial.hpp
+++ b/source/NumberProtocols/Serial.hpp
@@ -53,9 +53,9 @@ class Serial : public NumberProtocol {
 
     double getDecimalNumber() override;
 
-    void setParams(NumberProtocolParameters newParams) override;
+    void setParams(NumberProtocolConfig newParams) override;
 
-    NumberProtocolParameters getParams() override;
+    NumberProtocolConfig getParams() override;
 
   private:
     std::unique_ptr<IDiscreteGenerator> m_generator;

--- a/source/NumberProtocols/Subset.cpp
+++ b/source/NumberProtocols/Subset.cpp
@@ -59,7 +59,7 @@ double Subset::getDecimalNumber()
     return static_cast<double>(getIntegerNumber());
 }
 
-void Subset::setParams(NumberProtocolParameters newParams)
+void Subset::setParams(NumberProtocolConfig newParams)
 {
     auto subsetParams = newParams.protocols.getSubset();
     auto newMin = subsetParams.getMin();
@@ -75,12 +75,11 @@ void Subset::setParams(NumberProtocolParameters newParams)
     setSubset();
 }
 
-NumberProtocolParameters Subset::getParams()
+NumberProtocolConfig Subset::getParams()
 {
-    return NumberProtocolParameters(
+    return NumberProtocolConfig(
         m_range,
-        NumberProtocolParameters::Protocols(
-            NumberProtocolParameters::Subset(m_subsetMin, m_subsetMax)));
+        NumberProtocolParams(SubsetParams(m_subsetMin, m_subsetMax)));
 }
 
 // Private methods

--- a/source/NumberProtocols/Subset.hpp
+++ b/source/NumberProtocols/Subset.hpp
@@ -28,9 +28,9 @@ class Subset : public NumberProtocol {
 
     double getDecimalNumber() override;
 
-    void setParams(NumberProtocolParameters newParams) override;
+    void setParams(NumberProtocolConfig newParams) override;
 
-    NumberProtocolParameters getParams() override;
+    NumberProtocolConfig getParams() override;
 
   private:
     std::unique_ptr<IUniformGenerator> m_uniformGenerator;

--- a/source/NumberProtocols/Walk.cpp
+++ b/source/NumberProtocols/Walk.cpp
@@ -47,7 +47,7 @@ double Walk::getDecimalNumber()
     return static_cast<double>(getIntegerNumber());
 }
 
-void Walk::setParams(NumberProtocolParameters newParams)
+void Walk::setParams(NumberProtocolConfig newParams)
 {
     auto maxStep = newParams.protocols.getWalk().getMaxStep();
     auto newRange = newParams.getRange();
@@ -58,12 +58,10 @@ void Walk::setParams(NumberProtocolParameters newParams)
     setRange(newRange);
 }
 
-NumberProtocolParameters Walk::getParams()
+NumberProtocolConfig Walk::getParams()
 {
-    return NumberProtocolParameters(
-        m_range,
-        NumberProtocolParameters::Protocols(
-            NumberProtocolParameters::Walk(m_maxStep)));
+    return NumberProtocolConfig(m_range,
+                                NumberProtocolParams(WalkParams(m_maxStep)));
 }
 
 // Private methods

--- a/source/NumberProtocols/Walk.hpp
+++ b/source/NumberProtocols/Walk.hpp
@@ -92,9 +92,9 @@ class Walk : public NumberProtocol {
 
     double getDecimalNumber() override;
 
-    void setParams(NumberProtocolParameters newParams) override;
+    void setParams(NumberProtocolConfig newParams) override;
 
-    NumberProtocolParameters getParams() override;
+    NumberProtocolConfig getParams() override;
 
   private:
     std::unique_ptr<IUniformGenerator> m_generator;

--- a/source/Producers/CollectionsProducer.hpp
+++ b/source/Producers/CollectionsProducer.hpp
@@ -2,6 +2,7 @@
 #define CollectionsProducer_hpp
 
 #include "NumberProtocol.hpp"
+#include "NumberProtocolParameters.hpp"
 
 #include <memory>
 #include <stdexcept>
@@ -17,8 +18,8 @@ class CollectionsProducer {
 
     const T &getItem();
     std::vector<T> getCollection(int size);
-    NumberProtocolParameters::Protocols getParams();
-    void setParams(NumberProtocolParameters::Protocols newParams);
+    NumberProtocolParams getParams();
+    void setParams(NumberProtocolParams newParams);
     void setProtocol(std::unique_ptr<NumberProtocol> protocol);
     void setSource(std::vector<T> newSource);
     std::vector<T> getSource();
@@ -69,14 +70,13 @@ std::vector<T> CollectionsProducer<T>::getCollection(int size)
 }
 
 template<typename T>
-NumberProtocolParameters::Protocols CollectionsProducer<T>::getParams()
+NumberProtocolParams CollectionsProducer<T>::getParams()
 {
     return m_protocol->getParams().protocols;
 }
 
 template<typename T>
-void CollectionsProducer<T>::setParams(
-    NumberProtocolParameters::Protocols newParams)
+void CollectionsProducer<T>::setParams(NumberProtocolParams newParams)
 {
     if(newParams.getActiveProtocol() !=
        m_protocol->getParams().protocols.getActiveProtocol()) {
@@ -86,7 +86,7 @@ void CollectionsProducer<T>::setParams(
     }
 
     m_protocol->setParams(
-        NumberProtocolParameters(Range(0, m_source.size() - 1), newParams));
+        NumberProtocolConfig(Range(0, m_source.size() - 1), newParams));
 }
 
 template<typename T>

--- a/source/Producers/DurationsProducer.cpp
+++ b/source/Producers/DurationsProducer.cpp
@@ -44,12 +44,12 @@ std::vector<int> DurationsProducer::getSelectableDurations()
     return m_durationProtocol->getSelectableDurations();
 }
 
-NumberProtocolParameters::Protocols DurationsProducer::getParams()
+NumberProtocolParams DurationsProducer::getParams()
 {
     return m_numberProtocol->getParams().protocols;
 }
 
-void DurationsProducer::setParams(NumberProtocolParameters::Protocols newParams)
+void DurationsProducer::setParams(NumberProtocolParams newParams)
 {
     if(newParams.getActiveProtocol() !=
        m_numberProtocol->getParams().protocols.getActiveProtocol()) {
@@ -59,8 +59,8 @@ void DurationsProducer::setParams(NumberProtocolParameters::Protocols newParams)
     }
 
     m_numberProtocol->setParams(
-        NumberProtocolParameters(Range(0, m_durationCollectionSize - 1),
-                                 newParams));
+        NumberProtocolConfig(Range(0, m_durationCollectionSize - 1),
+                             newParams));
 
     notifyParamsChangeListeners();
 }

--- a/source/Producers/DurationsProducer.hpp
+++ b/source/Producers/DurationsProducer.hpp
@@ -3,6 +3,7 @@
 
 #include "DurationProtocol.hpp"
 #include "NumberProtocol.hpp"
+#include "NumberProtocolParameters.hpp"
 
 #include <functional>
 #include <map>
@@ -20,9 +21,9 @@ class DurationsProducer {
 
     std::vector<int> getSelectableDurations();
 
-    NumberProtocolParameters::Protocols getParams();
+    NumberProtocolParams getParams();
 
-    void setParams(NumberProtocolParameters::Protocols newParams);
+    void setParams(NumberProtocolParams newParams);
 
     int addListenerForParamsChange(std::function<void()> callback);
 

--- a/source/Producers/NumbersProducer.cpp
+++ b/source/Producers/NumbersProducer.cpp
@@ -1,5 +1,7 @@
 #include "NumbersProducer.hpp"
 
+#include "NumberProtocolParameters.hpp"
+
 #include <stdexcept>
 
 namespace aleatoric {
@@ -42,12 +44,12 @@ std::vector<double> NumbersProducer::getDecimalCollection(int size)
     return collection;
 }
 
-NumberProtocolParameters NumbersProducer::getParams()
+NumberProtocolConfig NumbersProducer::getParams()
 {
     return m_protocol->getParams();
 }
 
-void NumbersProducer::setParams(NumberProtocolParameters newParams)
+void NumbersProducer::setParams(NumberProtocolConfig newParams)
 {
     if(newParams.protocols.getActiveProtocol() !=
        m_protocol->getParams().protocols.getActiveProtocol()) {

--- a/source/Producers/NumbersProducer.hpp
+++ b/source/Producers/NumbersProducer.hpp
@@ -44,9 +44,9 @@ class NumbersProducer {
 
     std::vector<double> getDecimalCollection(int size);
 
-    NumberProtocolParameters getParams();
+    NumberProtocolConfig getParams();
 
-    void setParams(NumberProtocolParameters newParams);
+    void setParams(NumberProtocolConfig newParams);
 
     void setProtocol(std::unique_ptr<NumberProtocol> protocol);
 

--- a/tests/AdjacentStepsTest.cpp
+++ b/tests/AdjacentStepsTest.cpp
@@ -178,18 +178,16 @@ SCENARIO("Numbers::AdjacentSteps: params")
             REQUIRE(returnedRange.start == range.start);
             REQUIRE(returnedRange.end == range.end);
             REQUIRE(params.protocols.getActiveProtocol() ==
-                    NumberProtocolParameters::Protocols::ActiveProtocol::
-                        adjacentSteps);
+                    NumberProtocol::Type::adjacentSteps);
         }
     }
 
     WHEN("Set params")
     {
         Range newRange(20, 40);
-        NumberProtocolParameters newParams(
+        NumberProtocolConfig newParams(
             newRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::AdjacentSteps()));
+            NumberProtocolParams(AdjacentStepsParams()));
         instance.setParams(newParams);
 
         THEN("object state is updated")
@@ -206,10 +204,9 @@ SCENARIO("Numbers::AdjacentSteps: params")
         GIVEN("No numbers have been returned yet")
         {
             Range newRange(4, 7);
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::AdjacentSteps()));
+                NumberProtocolParams(AdjacentStepsParams()));
             instance.setParams(newParams);
 
             THEN("Generator distribution has equal probability for whole range")
@@ -227,10 +224,9 @@ SCENARIO("Numbers::AdjacentSteps: params")
             WHEN("It is outside the new range")
             {
                 Range newRange(lastNumber + 1, lastNumber + 5);
-                NumberProtocolParameters newParams(
+                NumberProtocolConfig newParams(
                     newRange,
-                    NumberProtocolParameters::Protocols(
-                        NumberProtocolParameters::AdjacentSteps()));
+                    NumberProtocolParams(AdjacentStepsParams()));
                 instance.setParams(newParams);
 
                 THEN("Generator dist has equal prob for whole range")
@@ -244,10 +240,9 @@ SCENARIO("Numbers::AdjacentSteps: params")
             WHEN("It is mid-range within new range")
             {
                 Range newRange(lastNumber - 2, lastNumber + 2);
-                NumberProtocolParameters newParams(
+                NumberProtocolConfig newParams(
                     newRange,
-                    NumberProtocolParameters::Protocols(
-                        NumberProtocolParameters::AdjacentSteps()));
+                    NumberProtocolParams(AdjacentStepsParams()));
                 instance.setParams(newParams);
 
                 THEN("Only numbers either side of it are selectable")
@@ -261,10 +256,9 @@ SCENARIO("Numbers::AdjacentSteps: params")
             WHEN("It is start of the new range")
             {
                 Range newRange(lastNumber, lastNumber + 4);
-                NumberProtocolParameters newParams(
+                NumberProtocolConfig newParams(
                     newRange,
-                    NumberProtocolParameters::Protocols(
-                        NumberProtocolParameters::AdjacentSteps()));
+                    NumberProtocolParams(AdjacentStepsParams()));
                 instance.setParams(newParams);
 
                 THEN("Only the number above is selectable")
@@ -278,10 +272,9 @@ SCENARIO("Numbers::AdjacentSteps: params")
             WHEN("It is end of the new range")
             {
                 Range newRange(lastNumber - 4, lastNumber);
-                NumberProtocolParameters newParams(
+                NumberProtocolConfig newParams(
                     newRange,
-                    NumberProtocolParameters::Protocols(
-                        NumberProtocolParameters::AdjacentSteps()));
+                    NumberProtocolParams(AdjacentStepsParams()));
                 instance.setParams(newParams);
 
                 THEN("Only the number below is selectable")

--- a/tests/BasicTest.cpp
+++ b/tests/BasicTest.cpp
@@ -93,17 +93,15 @@ SCENARIO("Numbers::Basic: params")
             REQUIRE(returnedRange.start == 1);
             REQUIRE(returnedRange.end == 10);
             REQUIRE(params.protocols.getActiveProtocol() ==
-                    NumberProtocolParameters::Protocols::ActiveProtocol::basic);
+                    NumberProtocol::Type::basic);
         }
     }
 
     WHEN("Set params")
     {
         Range newRange(20, 30);
-        NumberProtocolParameters newParams(
-            newRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::Basic()));
+        NumberProtocolConfig newParams(newRange,
+                                       NumberProtocolParams(BasicParams()));
         instance.setParams(newParams);
 
         THEN("object state is updated")

--- a/tests/CollectionsProducerTest.cpp
+++ b/tests/CollectionsProducerTest.cpp
@@ -162,8 +162,8 @@ SCENARIO("CollectionsProducer: using Subset")
             source,
             NumberProtocol::create(NumberProtocol::Type::subset));
 
-        instance.setParams(NumberProtocolParameters::Protocols(
-            NumberProtocolParameters::Subset(subsetMin, subsetMax)));
+        instance.setParams(
+            NumberProtocolParams(SubsetParams(subsetMin, subsetMax)));
 
         WHEN("A sample has been collected")
         {
@@ -225,8 +225,8 @@ SCENARIO("CollectionsProducer: using GroupedRepetition")
             source,
             NumberProtocol::create(NumberProtocol::Type::groupedRepetition));
 
-        instance.setParams(NumberProtocolParameters::Protocols(
-            NumberProtocolParameters::GroupedRepetition(groupings)));
+        instance.setParams(
+            NumberProtocolParams(GroupedRepetitionParams(groupings)));
 
         WHEN("Two samples each consisting of a full series set has been "
              "gathered")
@@ -274,8 +274,7 @@ SCENARIO("CollectionsProducer: using Ratio")
             source,
             NumberProtocol::create(NumberProtocol::Type::ratio));
 
-        instance.setParams(NumberProtocolParameters::Protocols(
-            NumberProtocolParameters::Ratio(ratios)));
+        instance.setParams(NumberProtocolParams(RatioParams(ratios)));
 
         WHEN("A full series sample has been gathered")
         {
@@ -315,8 +314,8 @@ SCENARIO("CollectionsProducer: using Precision")
                 source,
                 NumberProtocol::create(NumberProtocol::Type::precision));
 
-            instance.setParams(NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::Precision(distribution)));
+            instance.setParams(
+                NumberProtocolParams(PrecisionParams(distribution)));
 
             AND_WHEN("A sample is requested")
             {
@@ -387,8 +386,8 @@ SCENARIO("CollectionsProducer: using Periodic")
                 source,
                 NumberProtocol::create(NumberProtocol::Type::periodic));
 
-            instance.setParams(NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::Periodic(chanceOfRepetition)));
+            instance.setParams(
+                NumberProtocolParams(PeriodicParams(chanceOfRepetition)));
 
             WHEN("A sample has been gathered")
             {
@@ -454,8 +453,7 @@ SCENARIO("CollectionsProducer: using Walk")
             source,
             NumberProtocol::create(NumberProtocol::Type::walk));
 
-        instance.setParams(NumberProtocolParameters::Protocols(
-            NumberProtocolParameters::Walk(maxStep)));
+        instance.setParams(NumberProtocolParams(WalkParams(maxStep)));
 
         WHEN("A sample has been gathered")
         {
@@ -489,9 +487,8 @@ SCENARIO("CollectionsProducer: Get and set params (using cycle for test)")
             {
                 auto params = instance.getParams();
                 auto cycleParams = params.getCycle();
-                REQUIRE(
-                    params.getActiveProtocol() ==
-                    NumberProtocolParameters::Protocols::ActiveProtocol::cycle);
+                REQUIRE(params.getActiveProtocol() ==
+                        NumberProtocol::Type::cycle);
                 REQUIRE_FALSE(cycleParams.getReverseDirection());
                 REQUIRE_FALSE(cycleParams.getBidirectional());
             }
@@ -511,8 +508,7 @@ SCENARIO("CollectionsProducer: Get and set params (using cycle for test)")
 
     GIVEN("Params have been updated: change to reverse unidirectional")
     {
-        NumberProtocolParameters::Protocols newParams(
-            NumberProtocolParameters::Cycle(false, true));
+        NumberProtocolParams newParams(CycleParams(false, true));
 
         instance.setParams(newParams);
 
@@ -542,8 +538,7 @@ SCENARIO("CollectionsProducer: Get and set params (using cycle for test)")
         {
             // Provides Basic protocol params, not cycle
             REQUIRE_THROWS_AS(
-                instance.setParams(NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Basic())),
+                instance.setParams(NumberProtocolParams(BasicParams())),
                 std::invalid_argument);
         }
     }
@@ -565,13 +560,12 @@ SCENARIO("CollectionsProducer: Change protocol")
         {
             auto activeProtocol = instance.getParams().getActiveProtocol();
             REQUIRE(activeProtocol ==
-                    NumberProtocolParameters::Protocols::ActiveProtocol::cycle);
+                    NumberProtocol::Type::cycle);
         }
 
         THEN("A collection of items is as expected")
         {
-            instance.setParams(NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::Cycle(false, false)));
+            instance.setParams(NumberProtocolParams(CycleParams(false, false)));
 
             std::vector<char> expectedResult {'a', 'b', 'c', 'a', 'b', 'c'};
             auto set = instance.getCollection(expectedResult.size());
@@ -588,9 +582,8 @@ SCENARIO("CollectionsProducer: Change protocol")
         THEN("Active protocol is as expected")
         {
             auto activeProtocol = instance.getParams().getActiveProtocol();
-            REQUIRE(
-                activeProtocol ==
-                NumberProtocolParameters::Protocols::ActiveProtocol::serial);
+            REQUIRE(activeProtocol ==
+                    NumberProtocol::Type::serial);
         }
 
         THEN("Set of items is as expected with the protocol range configured "
@@ -621,8 +614,7 @@ SCENARIO("CollectionsProducer: Change source collection")
         NumberProtocol::create(NumberProtocol::Type::cycle));
 
     // NB: set to reverse bidirectional
-    instance.setParams(NumberProtocolParameters::Protocols(
-        NumberProtocolParameters::Cycle(true, true)));
+    instance.setParams(NumberProtocolParams(CycleParams(true, true)));
 
     WHEN("New source collection size is too small")
     {

--- a/tests/CycleTest.cpp
+++ b/tests/CycleTest.cpp
@@ -233,16 +233,15 @@ SCENARIO("Numbers::Cycle: params")
             REQUIRE_FALSE(cycleParams.getBidirectional());
             REQUIRE_FALSE(cycleParams.getReverseDirection());
             REQUIRE(params.protocols.getActiveProtocol() ==
-                    NumberProtocolParameters::Protocols::ActiveProtocol::cycle);
+                    NumberProtocol::Type::cycle);
         }
     }
 
     WHEN("Set params")
     {
-        NumberProtocolParameters newParams(
+        NumberProtocolConfig newParams(
             Range(10, 20),
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::Cycle(true, true)));
+            NumberProtocolParams(CycleParams(true, true)));
         instance.setParams(newParams);
 
         THEN("params should be updated")
@@ -274,11 +273,10 @@ SCENARIO("Numbers::Cycle: Set params: no numbers returned yet")
 
         bool newBidirectional = false;
         bool newReverseDirection = false;
-        NumberProtocolParameters newParams(
+        NumberProtocolConfig newParams(
             newRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::Cycle(newBidirectional,
-                                                newReverseDirection)));
+            NumberProtocolParams(
+                CycleParams(newBidirectional, newReverseDirection)));
         instance.setParams(newParams);
 
         THEN("A set of numbers should be as expected")
@@ -300,11 +298,10 @@ SCENARIO("Numbers::Cycle: Set params: no numbers returned yet")
 
         bool newBidirectional = false;
         bool newReverseDirection = true;
-        NumberProtocolParameters newParams(
+        NumberProtocolConfig newParams(
             newRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::Cycle(newBidirectional,
-                                                newReverseDirection)));
+            NumberProtocolParams(
+                CycleParams(newBidirectional, newReverseDirection)));
         instance.setParams(newParams);
 
         THEN("A set of numbers should be as expected")
@@ -326,11 +323,10 @@ SCENARIO("Numbers::Cycle: Set params: no numbers returned yet")
 
         bool newBidirectional = true;
         bool newReverseDirection = false;
-        NumberProtocolParameters newParams(
+        NumberProtocolConfig newParams(
             newRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::Cycle(newBidirectional,
-                                                newReverseDirection)));
+            NumberProtocolParams(
+                CycleParams(newBidirectional, newReverseDirection)));
         instance.setParams(newParams);
 
         THEN("A set of numbers should be as expected")
@@ -352,11 +348,10 @@ SCENARIO("Numbers::Cycle: Set params: no numbers returned yet")
 
         bool newBidirectional = true;
         bool newReverseDirection = true;
-        NumberProtocolParameters newParams(
+        NumberProtocolConfig newParams(
             newRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::Cycle(newBidirectional,
-                                                newReverseDirection)));
+            NumberProtocolParams(
+                CycleParams(newBidirectional, newReverseDirection)));
         instance.setParams(newParams);
 
         THEN("A set of numbers should be as expected")
@@ -390,11 +385,10 @@ SCENARIO("Numbers::Cycle: Set params: with last returned number")
         WHEN("Last number is mid new range")
         {
             Range newRange(lastNumber - 1, lastNumber + 1); // 2 - 4
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Cycle(newBidirectional,
-                                                    newReverseDirection)));
+                NumberProtocolParams(
+                    CycleParams(newBidirectional, newReverseDirection)));
             instance.setParams(newParams);
 
             THEN("The cycle continues as expected")
@@ -411,11 +405,10 @@ SCENARIO("Numbers::Cycle: Set params: with last returned number")
         WHEN("Last number is at end of new range")
         {
             Range newRange(lastNumber - 3, lastNumber); // 0 - 3
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Cycle(newBidirectional,
-                                                    newReverseDirection)));
+                NumberProtocolParams(
+                    CycleParams(newBidirectional, newReverseDirection)));
             instance.setParams(newParams);
 
             THEN("The cycle continues as expected")
@@ -432,11 +425,10 @@ SCENARIO("Numbers::Cycle: Set params: with last returned number")
         WHEN("Last number is at start of new range")
         {
             Range newRange(lastNumber, lastNumber + 2); // 3 - 5
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Cycle(newBidirectional,
-                                                    newReverseDirection)));
+                NumberProtocolParams(
+                    CycleParams(newBidirectional, newReverseDirection)));
             instance.setParams(newParams);
 
             THEN("The cycle continues as expected")
@@ -453,11 +445,10 @@ SCENARIO("Numbers::Cycle: Set params: with last returned number")
         WHEN("Last number not in new range")
         {
             Range newRange(lastNumber + 1, lastNumber + 3); // 4 - 6
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Cycle(newBidirectional,
-                                                    newReverseDirection)));
+                NumberProtocolParams(
+                    CycleParams(newBidirectional, newReverseDirection)));
             instance.setParams(newParams);
 
             THEN("Cycle jumps to start of new range")
@@ -486,11 +477,10 @@ SCENARIO("Numbers::Cycle: Set params: with last returned number")
         WHEN("Last number is mid new range")
         {
             Range newRange(lastNumber - 1, lastNumber + 1); // 0 - 2
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Cycle(newBidirectional,
-                                                    newReverseDirection)));
+                NumberProtocolParams(
+                    CycleParams(newBidirectional, newReverseDirection)));
             instance.setParams(newParams);
 
             THEN("The cycle continues as expected")
@@ -507,11 +497,10 @@ SCENARIO("Numbers::Cycle: Set params: with last returned number")
         WHEN("Last number is at end of new range")
         {
             Range newRange(lastNumber - 2, lastNumber); // -1, 1
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Cycle(newBidirectional,
-                                                    newReverseDirection)));
+                NumberProtocolParams(
+                    CycleParams(newBidirectional, newReverseDirection)));
             instance.setParams(newParams);
 
             THEN("The cycle continues as expected")
@@ -528,11 +517,10 @@ SCENARIO("Numbers::Cycle: Set params: with last returned number")
         WHEN("Last number is at start of new range")
         {
             Range newRange(lastNumber, lastNumber + 3); // 1 - 4
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Cycle(newBidirectional,
-                                                    newReverseDirection)));
+                NumberProtocolParams(
+                    CycleParams(newBidirectional, newReverseDirection)));
             instance.setParams(newParams);
 
             THEN("The cycle continues as expected")
@@ -549,11 +537,10 @@ SCENARIO("Numbers::Cycle: Set params: with last returned number")
         WHEN("Last number not in new range")
         {
             Range newRange(lastNumber + 1, lastNumber + 3); // 2 - 4
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Cycle(newBidirectional,
-                                                    newReverseDirection)));
+                NumberProtocolParams(
+                    CycleParams(newBidirectional, newReverseDirection)));
             instance.setParams(newParams);
 
             THEN("Cycle jumps to end of new range")
@@ -582,11 +569,10 @@ SCENARIO("Numbers::Cycle: Set params: with last returned number")
         WHEN("Last number is mid new range")
         {
             Range newRange(lastNumber - 1, lastNumber + 1); // 2 - 4
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Cycle(newBidirectional,
-                                                    newReverseDirection)));
+                NumberProtocolParams(
+                    CycleParams(newBidirectional, newReverseDirection)));
             instance.setParams(newParams);
 
             THEN("The cycle continues as expected")
@@ -603,11 +589,10 @@ SCENARIO("Numbers::Cycle: Set params: with last returned number")
         WHEN("Last number is at end of new range")
         {
             Range newRange(lastNumber - 3, lastNumber); // 0, 3
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Cycle(newBidirectional,
-                                                    newReverseDirection)));
+                NumberProtocolParams(
+                    CycleParams(newBidirectional, newReverseDirection)));
             instance.setParams(newParams);
 
             THEN("The cycle continues as expected")
@@ -624,11 +609,10 @@ SCENARIO("Numbers::Cycle: Set params: with last returned number")
         WHEN("Last number is at start of new range")
         {
             Range newRange(lastNumber, lastNumber + 2); // 3 - 5
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Cycle(newBidirectional,
-                                                    newReverseDirection)));
+                NumberProtocolParams(
+                    CycleParams(newBidirectional, newReverseDirection)));
             instance.setParams(newParams);
 
             THEN("The cycle continues as expected")
@@ -645,11 +629,10 @@ SCENARIO("Numbers::Cycle: Set params: with last returned number")
         WHEN("Last number not in new range")
         {
             Range newRange(lastNumber + 1, lastNumber + 3); // 4 - 6
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Cycle(newBidirectional,
-                                                    newReverseDirection)));
+                NumberProtocolParams(
+                    CycleParams(newBidirectional, newReverseDirection)));
             instance.setParams(newParams);
 
             THEN("Cycle jumps to start of new range")
@@ -678,11 +661,10 @@ SCENARIO("Numbers::Cycle: Set params: with last returned number")
         WHEN("Last number is mid new range")
         {
             Range newRange(lastNumber - 1, lastNumber + 1); // 0 - 2
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Cycle(newBidirectional,
-                                                    newReverseDirection)));
+                NumberProtocolParams(
+                    CycleParams(newBidirectional, newReverseDirection)));
             instance.setParams(newParams);
 
             THEN("The cycle continues as expected")
@@ -699,11 +681,10 @@ SCENARIO("Numbers::Cycle: Set params: with last returned number")
         WHEN("Last number is at end of new range")
         {
             Range newRange(lastNumber - 2, lastNumber); // -1, 1
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Cycle(newBidirectional,
-                                                    newReverseDirection)));
+                NumberProtocolParams(
+                    CycleParams(newBidirectional, newReverseDirection)));
             instance.setParams(newParams);
 
             THEN("The cycle continues as expected")
@@ -720,11 +701,10 @@ SCENARIO("Numbers::Cycle: Set params: with last returned number")
         WHEN("Last number is at start of new range")
         {
             Range newRange(lastNumber, lastNumber + 3); // 1 - 4
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Cycle(newBidirectional,
-                                                    newReverseDirection)));
+                NumberProtocolParams(
+                    CycleParams(newBidirectional, newReverseDirection)));
             instance.setParams(newParams);
 
             THEN("The cycle continues as expected")
@@ -741,11 +721,10 @@ SCENARIO("Numbers::Cycle: Set params: with last returned number")
         WHEN("Last number not in new range")
         {
             Range newRange(lastNumber + 1, lastNumber + 3); // 2 - 4
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Cycle(newBidirectional,
-                                                    newReverseDirection)));
+                NumberProtocolParams(
+                    CycleParams(newBidirectional, newReverseDirection)));
             instance.setParams(newParams);
 
             THEN("Cycle jumps to end of new range")

--- a/tests/DurationsProducerTest.cpp
+++ b/tests/DurationsProducerTest.cpp
@@ -309,9 +309,8 @@ SCENARIO("DurationsProducer: Get and set params (using Prescribed and Cycle "
             {
                 auto params = instance.getParams();
                 auto cycleParams = params.getCycle();
-                REQUIRE(
-                    params.getActiveProtocol() ==
-                    NumberProtocolParameters::Protocols::ActiveProtocol::cycle);
+                REQUIRE(params.getActiveProtocol() ==
+                        NumberProtocol::Type::cycle);
                 REQUIRE_FALSE(cycleParams.getReverseDirection());
                 REQUIRE_FALSE(cycleParams.getBidirectional());
             }
@@ -336,8 +335,7 @@ SCENARIO("DurationsProducer: Get and set params (using Prescribed and Cycle "
 
     GIVEN("Params have been updated: change to reverse unidirectional")
     {
-        NumberProtocolParameters::Protocols newParams(
-            NumberProtocolParameters::Cycle(false, true));
+        NumberProtocolParams newParams(CycleParams(false, true));
 
         instance.setParams(newParams);
 
@@ -372,8 +370,7 @@ SCENARIO("DurationsProducer: Get and set params (using Prescribed and Cycle "
         {
             // Provides Basic protocol params, not cycle
             REQUIRE_THROWS_AS(
-                instance.setParams(NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Basic())),
+                instance.setParams(NumberProtocolParams(BasicParams())),
                 std::invalid_argument);
         }
     }
@@ -394,14 +391,12 @@ SCENARIO("DurationsProducer: Change number protocol")
         THEN("Active protocol is as expected")
         {
             auto activeProtocol = instance.getParams().getActiveProtocol();
-            REQUIRE(activeProtocol ==
-                    NumberProtocolParameters::Protocols::ActiveProtocol::cycle);
+            REQUIRE(activeProtocol == NumberProtocol::Type::cycle);
         }
 
         THEN("Set of durations is as expected")
         {
-            instance.setParams(NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::Cycle(false, false)));
+            instance.setParams(NumberProtocolParams(CycleParams(false, false)));
 
             std::vector<int> expectedResult {1, 2, 3, 1, 2, 3};
             auto set = instance.getCollection(expectedResult.size());
@@ -418,9 +413,7 @@ SCENARIO("DurationsProducer: Change number protocol")
         THEN("Active protocol is as expected")
         {
             auto activeProtocol = instance.getParams().getActiveProtocol();
-            REQUIRE(
-                activeProtocol ==
-                NumberProtocolParameters::Protocols::ActiveProtocol::serial);
+            REQUIRE(activeProtocol == NumberProtocol::Type::serial);
         }
 
         THEN("Set of durations is as expected with the protocol range "
@@ -453,8 +446,7 @@ SCENARIO("DurationsProducer: Change duration protocol")
         NumberProtocol::create(NumberProtocol::Type::cycle));
 
     // NB: set to reverse bidirectional
-    instance.setParams(NumberProtocolParameters::Protocols(
-        NumberProtocolParameters::Cycle(true, true)));
+    instance.setParams(NumberProtocolParams(CycleParams(true, true)));
 
     // register after initial params setting directly above to avoid listener
     // getting called prematurely
@@ -682,8 +674,7 @@ SCENARIO("DurationsProducer: Observing changes to params (registering, "
         auto callbackTwoId = instance.addListenerForParamsChange(
             [&callbackTwoHasBeenCalled]() { callbackTwoHasBeenCalled = true; });
 
-        NumberProtocolParameters::Protocols newParams(
-            NumberProtocolParameters::Cycle(true, true));
+        NumberProtocolParams newParams(CycleParams(true, true));
 
         // setting params triggers params change listeners
         instance.setParams(newParams);

--- a/tests/GranularWalkTest.cpp
+++ b/tests/GranularWalkTest.cpp
@@ -199,8 +199,7 @@ SCENARIO("Numbers::GranularWalk: params")
         THEN("active protocol should be granular walk")
         {
             REQUIRE(params.protocols.getActiveProtocol() ==
-                    NumberProtocolParameters::Protocols::ActiveProtocol::
-                        granularWalk);
+                    NumberProtocol::Type::granularWalk);
         }
     }
 
@@ -208,10 +207,9 @@ SCENARIO("Numbers::GranularWalk: params")
     {
         Range newRange(20, 40);
         double newDeviationFactor = 0.1;
-        NumberProtocolParameters newParams(
+        NumberProtocolConfig newParams(
             newRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::GranularWalk(newDeviationFactor)));
+            NumberProtocolParams(GranularWalkParams(newDeviationFactor)));
 
         instance.setParams(newParams);
         auto params = instance.getParams();
@@ -274,10 +272,9 @@ SCENARIO("Numbers::GranularWalk: params")
         double newDeviationFactor = 0.1;
         Range newRange(lastNumber - 10, lastNumber + 10);
 
-        NumberProtocolParameters newParams(
+        NumberProtocolConfig newParams(
             newRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::GranularWalk(newDeviationFactor)));
+            NumberProtocolParams(GranularWalkParams(newDeviationFactor)));
 
         instance.setParams(newParams);
 
@@ -309,10 +306,9 @@ SCENARIO("Numbers::GranularWalk: params")
 
         THEN("Throw exception if too high")
         {
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::GranularWalk(devFactorTooHigh)));
+                NumberProtocolParams(GranularWalkParams(devFactorTooHigh)));
 
             REQUIRE_THROWS_AS(instance.setParams(newParams),
                               std::invalid_argument);
@@ -320,9 +316,8 @@ SCENARIO("Numbers::GranularWalk: params")
 
         THEN("Throw exception if too low")
         {
-            NumberProtocolParameters newParams(
-                newRange,
-                NumberProtocolParameters::GranularWalk(devFactorTooLow));
+            NumberProtocolConfig newParams(newRange,
+                                           GranularWalkParams(devFactorTooLow));
             REQUIRE_THROWS_AS(instance.setParams(newParams),
                               std::invalid_argument);
         }

--- a/tests/GroupedRepetitionTest.cpp
+++ b/tests/GroupedRepetitionTest.cpp
@@ -310,8 +310,7 @@ SCENARIO("Numbers::GroupedRepetition: params")
             REQUIRE(params.protocols.getGroupedRepetition().getGroupings() ==
                     groupings);
             REQUIRE(params.protocols.getActiveProtocol() ==
-                    NumberProtocolParameters::Protocols::ActiveProtocol::
-                        groupedRepetition);
+                    NumberProtocol::Type::groupedRepetition);
         }
     }
 
@@ -319,10 +318,9 @@ SCENARIO("Numbers::GroupedRepetition: params")
     {
         Range newRange(1, 2);
         std::vector<int> newGroupings {2};
-        NumberProtocolParameters newParams(
+        NumberProtocolConfig newParams(
             newRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::GroupedRepetition(newGroupings)));
+            NumberProtocolParams(GroupedRepetitionParams(newGroupings)));
 
         THEN("object is updated")
         {

--- a/tests/NoRepetitionTest.cpp
+++ b/tests/NoRepetitionTest.cpp
@@ -134,18 +134,16 @@ SCENARIO("Numbers::NoRepetition: params")
             REQUIRE(returnedRange.start == 1);
             REQUIRE(returnedRange.end == 10);
             REQUIRE(params.protocols.getActiveProtocol() ==
-                    NumberProtocolParameters::Protocols::ActiveProtocol::
-                        noRepetition);
+                    NumberProtocol::Type::noRepetition);
         }
     }
 
     WHEN("set params")
     {
         Range newRange(20, 30);
-        NumberProtocolParameters newParams(
+        NumberProtocolConfig newParams(
             newRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::NoRepetition()));
+            NumberProtocolParams(NoRepetitionParams()));
         instance.setParams(newParams);
 
         THEN("object state should be updated")
@@ -162,10 +160,9 @@ SCENARIO("Numbers::NoRepetition: params")
         GIVEN("No numbers have been returned yet")
         {
             Range newRange(11, 13);
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::NoRepetition()));
+                NumberProtocolParams(NoRepetitionParams()));
             instance.setParams(newParams);
 
             THEN("Generator distribution should be equal prob for new range")
@@ -182,10 +179,9 @@ SCENARIO("Numbers::NoRepetition: params")
             WHEN("That is outside the new range")
             {
                 Range newRange(lastNumber + 1, lastNumber + 4);
-                NumberProtocolParameters newParams(
+                NumberProtocolConfig newParams(
                     newRange,
-                    NumberProtocolParameters::Protocols(
-                        NumberProtocolParameters::NoRepetition()));
+                    NumberProtocolParams(NoRepetitionParams()));
                 instance.setParams(newParams);
                 THEN(
                     "Generator distribution should be equal prob for new range")
@@ -198,10 +194,9 @@ SCENARIO("Numbers::NoRepetition: params")
             WHEN("That is within the new range")
             {
                 Range newRange(lastNumber - 1, lastNumber + 1);
-                NumberProtocolParameters newParams(
+                NumberProtocolConfig newParams(
                     newRange,
-                    NumberProtocolParameters::Protocols(
-                        NumberProtocolParameters::NoRepetition()));
+                    NumberProtocolParams(NoRepetitionParams()));
                 instance.setParams(newParams);
 
                 THEN("That number should be disallowed on the next selection")

--- a/tests/NumbersProducerTest.cpp
+++ b/tests/NumbersProducerTest.cpp
@@ -30,9 +30,8 @@ SCENARIO("Numbers: Using Basic")
             NumberProtocol::create(NumberProtocol::Type::basic));
 
         instance.setParams(
-            NumberProtocolParameters(referenceRange,
-                                     NumberProtocolParameters::Protocols(
-                                         NumberProtocolParameters::Basic())));
+            NumberProtocolConfig(referenceRange,
+                                 NumberProtocolParams(BasicParams())));
 
         WHEN("A sample has been gathered")
         {
@@ -73,10 +72,9 @@ SCENARIO("Numbers: Using Cycle")
             NumbersProducer instance(
                 NumberProtocol::create(NumberProtocol::Type::cycle));
 
-            instance.setParams(NumberProtocolParameters(
+            instance.setParams(NumberProtocolConfig(
                 referenceRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Cycle(false, false))));
+                NumberProtocolParams(CycleParams(false, false))));
 
             AND_WHEN("A pair of cycles is requested")
             {
@@ -96,10 +94,9 @@ SCENARIO("Numbers: Using Cycle")
             NumbersProducer instance(
                 NumberProtocol::create(NumberProtocol::Type::cycle));
 
-            instance.setParams(NumberProtocolParameters(
+            instance.setParams(NumberProtocolConfig(
                 referenceRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Cycle(false, true))));
+                NumberProtocolParams(CycleParams(false, true))));
 
             AND_WHEN("A pair of cycles is requested")
             {
@@ -119,10 +116,9 @@ SCENARIO("Numbers: Using Cycle")
             NumbersProducer instance(
                 NumberProtocol::create(NumberProtocol::Type::cycle));
 
-            instance.setParams(NumberProtocolParameters(
+            instance.setParams(NumberProtocolConfig(
                 referenceRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Cycle(true, false))));
+                NumberProtocolParams(CycleParams(true, false))));
 
             AND_WHEN("A pair of cycles is requested")
             {
@@ -142,10 +138,9 @@ SCENARIO("Numbers: Using Cycle")
             NumbersProducer instance(
                 NumberProtocol::create(NumberProtocol::Type::cycle));
 
-            instance.setParams(NumberProtocolParameters(
+            instance.setParams(NumberProtocolConfig(
                 referenceRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Cycle(true, true))));
+                NumberProtocolParams(CycleParams(true, true))));
 
             AND_WHEN("A pair of cycles is requested")
             {
@@ -174,9 +169,8 @@ SCENARIO("Numbers: Using Serial")
             NumberProtocol::create(NumberProtocol::Type::serial));
 
         instance.setParams(
-            NumberProtocolParameters(referenceRange,
-                                     NumberProtocolParameters::Protocols(
-                                         NumberProtocolParameters::Serial())));
+            NumberProtocolConfig(referenceRange,
+                                 NumberProtocolParams(SerialParams())));
 
         WHEN("A full series sample set has been gathered")
         {
@@ -233,10 +227,9 @@ SCENARIO("Numbers: Using Subset")
         NumbersProducer instance(
             NumberProtocol::create(NumberProtocol::Type::subset));
 
-        instance.setParams(NumberProtocolParameters(
+        instance.setParams(NumberProtocolConfig(
             referenceRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::Subset(subsetMin, subsetMax))));
+            NumberProtocolParams(SubsetParams(subsetMin, subsetMax))));
 
         WHEN("A sample has been collected")
         {
@@ -298,10 +291,9 @@ SCENARIO("Numbers: Using GroupedRepetition")
         NumbersProducer instance(
             NumberProtocol::create(NumberProtocol::Type::groupedRepetition));
 
-        instance.setParams(NumberProtocolParameters(
+        instance.setParams(NumberProtocolConfig(
             referenceRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::GroupedRepetition(groupings))));
+            NumberProtocolParams(GroupedRepetitionParams(groupings))));
 
         WHEN("Two samples each consisting of a full series set has been "
              "gathered")
@@ -351,10 +343,9 @@ SCENARIO("Numbers: Using Ratio")
         NumbersProducer instance(
             NumberProtocol::create(NumberProtocol::Type::ratio));
 
-        instance.setParams(NumberProtocolParameters(
-            referenceRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::Ratio(ratios))));
+        instance.setParams(
+            NumberProtocolConfig(referenceRange,
+                                 NumberProtocolParams(RatioParams(ratios))));
 
         WHEN("A full series sample set has been gathered")
         {
@@ -392,10 +383,9 @@ SCENARIO("Numbers: Using Ratio")
         NumbersProducer instance(
             NumberProtocol::create(NumberProtocol::Type::ratio));
 
-        instance.setParams(NumberProtocolParameters(
-            referenceRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::Ratio(ratios))));
+        instance.setParams(
+            NumberProtocolConfig(referenceRange,
+                                 NumberProtocolParams(RatioParams(ratios))));
 
         WHEN("A full series sample set has been gathered")
         {
@@ -450,10 +440,9 @@ SCENARIO("Numbers: Using Precision")
             NumbersProducer instance(
                 NumberProtocol::create(NumberProtocol::Type::precision));
 
-            instance.setParams(NumberProtocolParameters(
+            instance.setParams(NumberProtocolConfig(
                 referenceRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Precision(distribution))));
+                NumberProtocolParams(PrecisionParams(distribution))));
 
             AND_WHEN("A sample is requested")
             {
@@ -477,10 +466,9 @@ SCENARIO("Numbers: Using Precision")
             NumbersProducer instance(
                 NumberProtocol::create(NumberProtocol::Type::precision));
 
-            instance.setParams(NumberProtocolParameters(
+            instance.setParams(NumberProtocolConfig(
                 referenceRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Precision(distribution))));
+                NumberProtocolParams(PrecisionParams(distribution))));
 
             AND_WHEN("A sample is requested")
             {
@@ -506,10 +494,9 @@ SCENARIO("Numbers: Using NoRepetition")
     NumbersProducer instance(
         NumberProtocol::create(NumberProtocol::Type::noRepetition));
 
-    instance.setParams(NumberProtocolParameters(
-        referenceRange,
-        NumberProtocolParameters::Protocols(
-            NumberProtocolParameters::NoRepetition())));
+    instance.setParams(
+        NumberProtocolConfig(referenceRange,
+                             NumberProtocolParams(NoRepetitionParams())));
 
     GIVEN("The Producer has been instantiated")
     {
@@ -553,10 +540,9 @@ SCENARIO("Numbers: Using Periodic")
             NumbersProducer instance(
                 NumberProtocol::create(NumberProtocol::Type::periodic));
 
-            instance.setParams(NumberProtocolParameters(
+            instance.setParams(NumberProtocolConfig(
                 referenceRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Periodic(0.5))));
+                NumberProtocolParams(PeriodicParams(0.5))));
 
             WHEN("A sample has been gathered")
             {
@@ -586,10 +572,9 @@ SCENARIO("Numbers: Using Periodic")
             NumbersProducer instance(
                 NumberProtocol::create(NumberProtocol::Type::periodic));
 
-            instance.setParams(NumberProtocolParameters(
+            instance.setParams(NumberProtocolConfig(
                 referenceRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Periodic(0.0))));
+                NumberProtocolParams(PeriodicParams(0.0))));
 
             WHEN("A sample has been gathered")
             {
@@ -620,10 +605,9 @@ SCENARIO("Numbers: Using Periodic")
             NumbersProducer instance(
                 NumberProtocol::create(NumberProtocol::Type::periodic));
 
-            instance.setParams(NumberProtocolParameters(
+            instance.setParams(NumberProtocolConfig(
                 referenceRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Periodic(1.0))));
+                NumberProtocolParams(PeriodicParams(1.0))));
 
             WHEN("A sample has been gathered")
             {
@@ -651,10 +635,9 @@ SCENARIO("Numbers: Using AdjacentSteps")
         NumbersProducer instance(
             NumberProtocol::create(NumberProtocol::Type::adjacentSteps));
 
-        instance.setParams(NumberProtocolParameters(
-            referenceRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::AdjacentSteps())));
+        instance.setParams(
+            NumberProtocolConfig(referenceRange,
+                                 NumberProtocolParams(AdjacentStepsParams())));
 
         WHEN("A sample has been gathered")
         {
@@ -700,10 +683,9 @@ SCENARIO("Numbers: Using Walk")
         NumbersProducer instance(
             NumberProtocol::create(NumberProtocol::Type::walk));
 
-        instance.setParams(NumberProtocolParameters(
-            referenceRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::Walk(maxStep))));
+        instance.setParams(
+            NumberProtocolConfig(referenceRange,
+                                 NumberProtocolParams(WalkParams(maxStep))));
 
         WHEN("A sample has been gathered")
         {
@@ -750,10 +732,9 @@ SCENARIO("Numbers: Using GranularWalk")
         NumbersProducer instance(
             NumberProtocol::create(NumberProtocol::Type::granularWalk));
 
-        instance.setParams(NumberProtocolParameters(
+        instance.setParams(NumberProtocolConfig(
             referenceRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::GranularWalk(deviationFactor))));
+            NumberProtocolParams(GranularWalkParams(deviationFactor))));
 
         WHEN("A sample has been gathered")
         {
@@ -795,10 +776,9 @@ SCENARIO("Numbers: Get and set params using Cycle")
     NumbersProducer instance(
         NumberProtocol::create(NumberProtocol::Type::cycle));
 
-    instance.setParams(NumberProtocolParameters(
-        referenceRange,
-        NumberProtocolParameters::Protocols(
-            NumberProtocolParameters::Cycle(false, false))));
+    instance.setParams(
+        NumberProtocolConfig(referenceRange,
+                             NumberProtocolParams(CycleParams(false, false))));
 
     GIVEN("Params have not been changed from initial setting")
     {
@@ -812,9 +792,8 @@ SCENARIO("Numbers: Get and set params using Cycle")
             {
                 REQUIRE(returnedRange.start == referenceRange.start);
                 REQUIRE(returnedRange.end == referenceRange.end);
-                REQUIRE(
-                    params.protocols.getActiveProtocol() ==
-                    NumberProtocolParameters::Protocols::ActiveProtocol::cycle);
+                REQUIRE(params.protocols.getActiveProtocol() ==
+                        NumberProtocol::Type::cycle);
                 REQUIRE_FALSE(cycleParams.getBidirectional());
                 REQUIRE_FALSE(cycleParams.getReverseDirection());
             }
@@ -836,10 +815,9 @@ SCENARIO("Numbers: Get and set params using Cycle")
           "range")
     {
         Range newRange(1, 5);
-        NumberProtocolParameters newParams(
+        NumberProtocolConfig newParams(
             newRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::Cycle(false, true)));
+            NumberProtocolParams(CycleParams(false, true)));
 
         instance.setParams(newParams);
 
@@ -871,10 +849,9 @@ SCENARIO("Numbers: Get and set params using Cycle")
         THEN("Exception is thrown")
         {
             // Provides Basic protocol params, not cycle
-            REQUIRE_THROWS_AS(instance.setParams(NumberProtocolParameters(
+            REQUIRE_THROWS_AS(instance.setParams(NumberProtocolConfig(
                                   Range(20, 30),
-                                  NumberProtocolParameters::Protocols(
-                                      NumberProtocolParameters::Basic()))),
+                                  NumberProtocolParams(BasicParams()))),
                               std::invalid_argument);
         }
     }
@@ -896,15 +873,14 @@ SCENARIO("Numbers: Change protocol")
             auto activeProtocol =
                 instance.getParams().protocols.getActiveProtocol();
             REQUIRE(activeProtocol ==
-                    NumberProtocolParameters::Protocols::ActiveProtocol::cycle);
+                    NumberProtocol::Type::cycle);
         }
 
         THEN("Set of numbers is as expected")
         {
-            instance.setParams(NumberProtocolParameters(
+            instance.setParams(NumberProtocolConfig(
                 referenceRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Cycle(false, false))));
+                NumberProtocolParams(CycleParams(false, false))));
 
             std::vector<int> expectedResult {1, 2, 3, 1, 2, 3};
             auto set = instance.getIntegerCollection(expectedResult.size());
@@ -922,17 +898,15 @@ SCENARIO("Numbers: Change protocol")
         {
             auto activeProtocol =
                 instance.getParams().protocols.getActiveProtocol();
-            REQUIRE(
-                activeProtocol ==
-                NumberProtocolParameters::Protocols::ActiveProtocol::periodic);
+            REQUIRE(activeProtocol ==
+                    NumberProtocol::Type::periodic);
         }
 
         THEN("Set of numbers is as expected")
         {
-            instance.setParams(NumberProtocolParameters(
+            instance.setParams(NumberProtocolConfig(
                 referenceRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Periodic(1.0))));
+                NumberProtocolParams(PeriodicParams(1.0))));
 
             // use as reference number for set gathered next
             auto firstNumber = instance.getIntegerNumber();

--- a/tests/PeriodicTest.cpp
+++ b/tests/PeriodicTest.cpp
@@ -204,9 +204,8 @@ SCENARIO("Numbers::Periodic: params")
 
             REQUIRE(params.protocols.getPeriodic().getChanceOfRepetition() ==
                     0.5);
-            REQUIRE(
-                params.protocols.getActiveProtocol() ==
-                NumberProtocolParameters::Protocols::ActiveProtocol::periodic);
+            REQUIRE(params.protocols.getActiveProtocol() ==
+                    NumberProtocol::Type::periodic);
         }
     }
 
@@ -217,11 +216,9 @@ SCENARIO("Numbers::Periodic: params")
             THEN("An exception is thrown")
             {
                 double invalidPeriodicity = -0.1;
-                NumberProtocolParameters newParams(
+                NumberProtocolConfig newParams(
                     Range(0, 1),
-                    NumberProtocolParameters::Protocols(
-                        NumberProtocolParameters::Periodic(
-                            invalidPeriodicity)));
+                    NumberProtocolParams(PeriodicParams(invalidPeriodicity)));
 
                 REQUIRE_THROWS_AS(instance.setParams(newParams),
                                   std::invalid_argument);
@@ -233,11 +230,9 @@ SCENARIO("Numbers::Periodic: params")
             THEN("An exception is thrown")
             {
                 double invalidPeriodicity = 1.1;
-                NumberProtocolParameters newParams(
+                NumberProtocolConfig newParams(
                     Range(0, 1),
-                    NumberProtocolParameters::Protocols(
-                        NumberProtocolParameters::Periodic(
-                            invalidPeriodicity)));
+                    NumberProtocolParams(PeriodicParams(invalidPeriodicity)));
 
                 REQUIRE_THROWS_AS(instance.setParams(newParams),
                                   std::invalid_argument);
@@ -247,10 +242,9 @@ SCENARIO("Numbers::Periodic: params")
         AND_WHEN("The value is valid")
         {
             double newPeriodicity = 1.0;
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 Range(0, 1),
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Periodic(newPeriodicity)));
+                NumberProtocolParams(PeriodicParams(newPeriodicity)));
             instance.setParams(newParams);
 
             THEN("The object state is updated")
@@ -285,10 +279,9 @@ SCENARIO("Numbers::Periodic: params")
         THEN("The object state is updated")
         {
             Range newRange(11, 20);
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Periodic(chanceOfRepetition)));
+                NumberProtocolParams(PeriodicParams(chanceOfRepetition)));
 
             instance.setParams(newParams);
             auto params = instance.getParams();
@@ -300,10 +293,9 @@ SCENARIO("Numbers::Periodic: params")
         AND_WHEN("No numbers have been returned yet")
         {
             Range newRange(11, 13); // was (1, 10)
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Periodic(chanceOfRepetition)));
+                NumberProtocolParams(PeriodicParams(chanceOfRepetition)));
 
             instance.setParams(newParams);
 
@@ -321,10 +313,9 @@ SCENARIO("Numbers::Periodic: params")
             auto lastNumber = instance.getIntegerNumber();
             Range newRange(lastNumber + 1,
                            lastNumber + 3); // size of 3
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Periodic(chanceOfRepetition)));
+                NumberProtocolParams(PeriodicParams(chanceOfRepetition)));
 
             instance.setParams(newParams);
 
@@ -344,10 +335,9 @@ SCENARIO("Numbers::Periodic: params")
                            lastNumber + 2); // size of 5
             double newChanceOfRepetition = 0.25;
 
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Periodic(newChanceOfRepetition)));
+                NumberProtocolParams(PeriodicParams(newChanceOfRepetition)));
 
             instance.setParams(newParams);
 

--- a/tests/PrecisionTest.cpp
+++ b/tests/PrecisionTest.cpp
@@ -126,9 +126,8 @@ SCENARIO("Numbers:Precision: params")
             REQUIRE(returnedRange.end == 4);
             REQUIRE(params.protocols.getPrecision().getDistribution() ==
                     distribution);
-            REQUIRE(
-                params.protocols.getActiveProtocol() ==
-                NumberProtocolParameters::Protocols::ActiveProtocol::precision);
+            REQUIRE(params.protocols.getActiveProtocol() ==
+                    NumberProtocol::Type::precision);
         }
     }
 
@@ -136,10 +135,9 @@ SCENARIO("Numbers:Precision: params")
     {
         Range newRange(11, 15);
         std::vector<double> newDistribution {0.2, 0.2, 0.2, 0.2, 0.2};
-        NumberProtocolParameters newParams(
+        NumberProtocolConfig newParams(
             newRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::Precision(newDistribution)));
+            NumberProtocolParams(PrecisionParams(newDistribution)));
         instance.setParams(newParams);
 
         THEN("Object state is updated")
@@ -176,10 +174,9 @@ SCENARIO("Numbers:Precision: params")
     {
         Range newRange(1, 2);
         std::vector<double> newDistribution {1};
-        NumberProtocolParameters newParams(
+        NumberProtocolConfig newParams(
             newRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::Precision(newDistribution)));
+            NumberProtocolParams(PrecisionParams(newDistribution)));
 
         THEN("Throw exception")
         {

--- a/tests/RatioTest.cpp
+++ b/tests/RatioTest.cpp
@@ -224,7 +224,7 @@ SCENARIO("Numbers::Ratio: params")
             REQUIRE(returnedRange.end == 3);
             REQUIRE(params.protocols.getRatio().getRatios() == ratios);
             REQUIRE(params.protocols.getActiveProtocol() ==
-                    NumberProtocolParameters::Protocols::ActiveProtocol::ratio);
+                    NumberProtocol::Type::ratio);
         }
     }
 
@@ -232,10 +232,9 @@ SCENARIO("Numbers::Ratio: params")
     {
         Range newRange(4, 6);
         std::vector<int> newRatios {1, 2, 3};
-        NumberProtocolParameters newParams(
+        NumberProtocolConfig newParams(
             newRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::Ratio(newRatios)));
+            NumberProtocolParams(RatioParams(newRatios)));
         instance.setParams(newParams);
 
         THEN("Object is updated")
@@ -266,10 +265,9 @@ SCENARIO("Numbers::Ratio: params")
     {
         Range newRange(4, 6);
         std::vector<int> newRatios {2, 3};
-        NumberProtocolParameters newParams(
+        NumberProtocolConfig newParams(
             newRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::Ratio(newRatios)));
+            NumberProtocolParams(RatioParams(newRatios)));
 
         THEN("Throw exception")
         {

--- a/tests/SerialTest.cpp
+++ b/tests/SerialTest.cpp
@@ -165,19 +165,16 @@ SCENARIO("Numbers::Serial: params")
         {
             REQUIRE(returnedRange.start == 1);
             REQUIRE(returnedRange.end == 3);
-            REQUIRE(
-                params.protocols.getActiveProtocol() ==
-                NumberProtocolParameters::Protocols::ActiveProtocol::serial);
+            REQUIRE(params.protocols.getActiveProtocol() ==
+                    NumberProtocol::Type::serial);
         }
     }
 
     WHEN("Set params")
     {
         Range newRange(4, 9);
-        NumberProtocolParameters newParams(
-            newRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::Serial()));
+        NumberProtocolConfig newParams(newRange,
+                                       NumberProtocolParams(SerialParams()));
         instance.setParams(newParams);
 
         THEN("The object state is updated")

--- a/tests/SubsetTest.cpp
+++ b/tests/SubsetTest.cpp
@@ -297,9 +297,8 @@ SCENARIO("Numbers::subset: params")
             REQUIRE(returnedRange.end == 10);
             REQUIRE(subsetParams.getMin() == subsetMin);
             REQUIRE(subsetParams.getMax() == subsetMax);
-            REQUIRE(
-                params.protocols.getActiveProtocol() ==
-                NumberProtocolParameters::Protocols::ActiveProtocol::subset);
+            REQUIRE(params.protocols.getActiveProtocol() ==
+                    NumberProtocol::Type::subset);
         }
     }
 
@@ -308,10 +307,9 @@ SCENARIO("Numbers::subset: params")
         Range newRange(20, 30);
         int newMin = 3;
         int newMax = 5;
-        NumberProtocolParameters newParams(
+        NumberProtocolConfig newParams(
             newRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::Subset(newMin, newMax)));
+            NumberProtocolParams(SubsetParams(newMin, newMax)));
         instance.setParams(newParams);
 
         auto params = instance.getParams();
@@ -362,10 +360,9 @@ SCENARIO("Numbers::subset: params")
         {
             int newMin = 0;
             int newMax = 7;
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 Range(20, 30),
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Subset(newMin, newMax)));
+                NumberProtocolParams(SubsetParams(newMin, newMax)));
 
             THEN("Throw execption")
             {
@@ -378,10 +375,9 @@ SCENARIO("Numbers::subset: params")
         {
             int newMin = 8;
             int newMax = 7;
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 Range(20, 30),
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Subset(newMin, newMax)));
+                NumberProtocolParams(SubsetParams(newMin, newMax)));
 
             THEN("Throw execption")
             {
@@ -395,10 +391,9 @@ SCENARIO("Numbers::subset: params")
             Range newRange(20, 30);
             int newMin = 8;
             int newMax = newRange.size + 1;
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Subset(newMin, newMax)));
+                NumberProtocolParams(SubsetParams(newMin, newMax)));
 
             THEN("Throw execption")
             {

--- a/tests/WalkTest.cpp
+++ b/tests/WalkTest.cpp
@@ -203,7 +203,7 @@ SCENARIO("Numbers::Walk: params")
         THEN("active protocol is set correctly")
         {
             REQUIRE(params.protocols.getActiveProtocol() ==
-                    NumberProtocolParameters::Protocols::ActiveProtocol::walk);
+                    NumberProtocol::Type::walk);
         }
     }
 
@@ -212,10 +212,9 @@ SCENARIO("Numbers::Walk: params")
         int newMaxStep = 3;
         Range newRange(20, 30);
 
-        NumberProtocolParameters newParams(
+        NumberProtocolConfig newParams(
             newRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::Walk(newMaxStep)));
+            NumberProtocolParams(WalkParams(newMaxStep)));
 
         instance.setParams(newParams);
         auto params = instance.getParams();
@@ -273,10 +272,9 @@ SCENARIO("Numbers::Walk: params")
         int newMaxStep = 3;
         Range newRange(lastNumber - 20, lastNumber + 20);
 
-        NumberProtocolParameters newParams(
+        NumberProtocolConfig newParams(
             newRange,
-            NumberProtocolParameters::Protocols(
-                NumberProtocolParameters::Walk(newMaxStep)));
+            NumberProtocolParams(WalkParams(newMaxStep)));
 
         instance.setParams(newParams);
 
@@ -296,10 +294,9 @@ SCENARIO("Numbers::Walk: params")
         AND_WHEN("it is greater than new range size")
         {
             auto newMaxStep = newRange.size + 1;
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Walk(newMaxStep)));
+                NumberProtocolParams(WalkParams(newMaxStep)));
 
             THEN("An exception is thrown")
             {
@@ -311,10 +308,9 @@ SCENARIO("Numbers::Walk: params")
         AND_WHEN("it is less than 1")
         {
             int newMaxStep = 0;
-            NumberProtocolParameters newParams(
+            NumberProtocolConfig newParams(
                 newRange,
-                NumberProtocolParameters::Protocols(
-                    NumberProtocolParameters::Walk(newMaxStep)));
+                NumberProtocolParams(WalkParams(newMaxStep)));
 
             THEN("An exception is thrown")
             {


### PR DESCRIPTION
Rename the individual number protocol params classes. E.g. Serial -> SerialParams
Un-nest all params related classes
Rename Protocols to NumberProtocolParams and NumberProtocolParameters to NumberProtocolConfig
Remove ActiveProtocol enum and reuse NumberProtocol::Type instead